### PR TITLE
Refine scheduling UX and dashboard layouts

### DIFF
--- a/src/components/ZoneCard.jsx
+++ b/src/components/ZoneCard.jsx
@@ -2,20 +2,48 @@ import React from 'react'
 import { motion } from 'framer-motion'
 
 export default function ZoneCard({z, onPlay, onStop, onVolume, onOpen}){
+  const statusClass = z.online ? 'bg-emerald-500/20 text-emerald-200' : 'bg-rose-500/20 text-rose-200'
+
   return (
-    <motion.div layout className="glass p-4 flex items-center justify-between">
-      <div className="flex items-center gap-3">
-        <div className={`w-3 h-3 rounded-full ${z.online?'bg-green-400':'bg-red-500'}`}></div>
-        <div>
-          <div className="font-semibold">{z.name || z.ip}</div>
-          <div className="text-sm text-white/60">{z.zone || 'Без зоны'} · {z.ip}</div>
+    <motion.div
+      layout
+      className="glass rounded-xl p-4 shadow-glass flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
+    >
+      <div className="flex flex-col gap-2 min-w-0">
+        <div className="flex items-center gap-3">
+          <div className={`h-2.5 w-2.5 rounded-full ${z.online ? 'bg-emerald-400' : 'bg-rose-500'}`} />
+          <div className="min-w-0">
+            <div className="text-xs uppercase tracking-wide text-white/50">Устройство</div>
+            <div className="text-lg font-semibold truncate">{z.name || z.ip}</div>
+          </div>
+          <span className={`ml-auto px-3 py-1 text-xs rounded-full ${statusClass}`}>
+            {z.online ? 'Online' : 'Offline'}
+          </span>
+        </div>
+        <div className="text-sm text-white/60 truncate">
+          {(z.zone || 'Без зоны')} · {z.ip || '—'}
         </div>
       </div>
-      <div className="flex items-center gap-2">
-        <button className="btn" onClick={onPlay}>▶</button>
-        <button className="btn" onClick={onStop}>⏹</button>
-        <input className="w-28 accent-white" type="range" min="0" max="100" defaultValue={z.volume ?? 70} onChange={(e)=>onVolume(+e.target.value)} />
-        <button className="btn" onClick={onOpen}>Подробнее</button>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:text-right sm:min-w-[260px]">
+        <div className="flex flex-wrap items-center gap-2">
+          <button className="btn min-w-[2.75rem]" onClick={onPlay}>▶</button>
+          <button className="btn min-w-[2.75rem]" onClick={onStop}>⏹</button>
+        </div>
+        <div className="flex flex-col gap-1 sm:min-w-[160px]">
+          <span className="text-xs uppercase tracking-wide text-white/60">Громкость</span>
+          <input
+            className="accent-white/90"
+            type="range"
+            min="0"
+            max="100"
+            defaultValue={z.volume ?? 70}
+            onChange={(e)=>onVolume?.(+e.target.value)}
+          />
+        </div>
+        <div className="flex justify-end">
+          <button className="btn" onClick={onOpen}>Подробнее</button>
+        </div>
       </div>
     </motion.div>
   )

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -35,20 +35,49 @@ export default function Dashboard(){
 
       <Modal open={!!active} onClose={()=>setActive(null)} title={`Устройство ${active?.name || active?.ip || ''}`}>
         {active && (
-          <div className="space-y-3">
-            <div className="grid grid-cols-2 gap-3">
-              <div className="glass p-3">
-                <div className="text-sm text-white/60">IP</div>
-                <div className="font-mono">{active.ip}</div>
-              </div>
-              <div className="glass p-3">
-                <div className="text-sm text-white/60">Версия</div>
-                <div className="font-mono">{active.ver || '-'}</div>
+          <div className="space-y-6">
+            <div className="glass rounded-lg border border-white/10 p-4 space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="text-lg font-semibold">{active.name || active.ip}</div>
+                  <div className="text-sm text-white/60">
+                    {active.zone ? `Зона: ${active.zone}` : 'Сетевой аудиоузел в сети'}
+                  </div>
+                </div>
+                <span className={`px-3 py-1 text-xs rounded-full ${active.online ? 'bg-emerald-500/20 text-emerald-200' : 'bg-rose-500/20 text-rose-200'}`}>
+                  {active.online ? 'Online' : 'Offline'}
+                </span>
               </div>
             </div>
-            <div className="flex gap-2">
-              <button className="btn" onClick={()=>api.play(active.ip,'demo.mp3')}>▶ Проиграть demo.mp3</button>
-              <button className="btn" onClick={()=>api.stop(active.ip)}>⏹ Стоп</button>
+
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="glass rounded-lg border border-white/10 p-4">
+                <dt className="text-xs uppercase tracking-wide text-white/50">IP адрес</dt>
+                <dd className="mt-1 font-mono text-sm">{active.ip}</dd>
+              </div>
+              <div className="glass rounded-lg border border-white/10 p-4">
+                <dt className="text-xs uppercase tracking-wide text-white/50">Версия прошивки</dt>
+                <dd className="mt-1 font-mono text-sm">{active.ver || '—'}</dd>
+              </div>
+              <div className="glass rounded-lg border border-white/10 p-4">
+                <dt className="text-xs uppercase tracking-wide text-white/50">Статус</dt>
+                <dd className="mt-1 flex items-center gap-2 text-sm">
+                  <span className={`h-2.5 w-2.5 rounded-full ${active.online ? 'bg-emerald-400' : 'bg-rose-500'}`} />
+                  {active.online ? 'Устройство онлайн' : 'Недоступно'}
+                </dd>
+              </div>
+              <div className="glass rounded-lg border border-white/10 p-4">
+                <dt className="text-xs uppercase tracking-wide text-white/50">Текущая громкость</dt>
+                <dd className="mt-1 text-sm">{active.volume != null ? `${active.volume}%` : '—'}</dd>
+              </div>
+            </dl>
+
+            <div className="glass rounded-lg border border-white/10 p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-white/70">Управление воспроизведением</div>
+              <div className="flex flex-wrap gap-2">
+                <button className="btn" onClick={()=>api.play(active.ip,'demo.mp3')}>▶ Воспроизвести demo.mp3</button>
+                <button className="btn glass" onClick={()=>api.stop(active.ip)}>⏹ Остановить</button>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- replace prompt-based zone and playlist actions with styled modals and demo seed data on the schedule page
- add safe drag-and-drop handling plus fallback devices to keep the showcase populated
- redesign the shared zone card and dashboard details modal for a responsive glassmorphism layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc1e0faa4c832b8685632c2c295e81